### PR TITLE
Per version source with defaults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,6 @@ Style/MultilineBlockChain:
 
 Metrics/LineLength:
   Max: 120
+
+Metrics/AbcSize:
+  Max: 25

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Installs the Microsoft Office Developer Tools for Visual Studio 2012. Add this t
 
 This cookbook makes the `visualstudio_edition` and `visualstudio_update` resource definitions available.
 
-For example, to install Visual Studio 2010 using the `visualstudio_edition` definition:
+For example, to install Visual Studio 2015 Pro using the `visualstudio_edition` definition:
 
 ```ruby
 visualstudio_edition 'vs_2015_professional' do

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This Chef cookbook installs Visual Studio 2010, 2012, 2013, 2015 from an ISO.
 
 # Requirements
 
-This cookbook assumes the appropriate version of the .NET framework has already been installed before running the VisualStudio cookbook. To install .NET you can use the [dotnetframework cookbook](https://github.com/daptiv/dotnetframework). You must reboot the system after the .NET installation and before the VisualStudio installation.
+This cookbook assumes the appropriate version of the .NET framework has already been installed before running the VisualStudio cookbook. To install .NET you can use the [dotnetframework cookbook](https://supermarket.chef.io/cookbooks/dotnetframework). You must reboot the system after the .NET installation and before the VisualStudio installation.
 
 - VisualStudio 2010, 2012, and 2013 require .NET 4.5.x.
 - VisualStudio 2015 requires .NET 4.6.
 
-This cookbook requires 7-zip to be installed so it can extract the ISO. To ensure this happens this cookbook includes the [seven_zip](https://github.com/daptiv/seven_zip) default recipe.
+This cookbook requires 7-zip to be installed so it can extract the ISO. To ensure this happens this cookbook includes the [seven_zip](https://supermarket.chef.io/cookbooks/seven_zip) default recipe.
 
-NOTE - This cookbook cannot be installed over naked WinRM, i.e. knife-winrm or test-kitchen without failing with error 1603. This cookbook will work via Vagrant because Vagrant wraps Windows provisioners in a scheduled task.
+NOTE - This cookbook cannot be installed over naked WinRM, i.e. knife-winrm without failing with error 1603. This cookbook will work via test-kithen with an elevated user.
 
 ## Supported Visual Studio Editions/Versions
 - 2010 Professional
@@ -25,9 +25,10 @@ NOTE - This cookbook cannot be installed over naked WinRM, i.e. knife-winrm or t
 - 2013 Test Professional
 - 2013 Premium
 - 2013 Ultimate
-- 2013 Community (Update 5)
+- 2013 Community
 - 2015 Enterprise
 - 2015 Professional
+- 2015 Test Professional
 - 2015 Community
 
 ## Supported OSs
@@ -48,7 +49,7 @@ If you _really_ want to install VS 2015 on Windows Server 2012R2 over naked WinR
 
 # Attributes
 
-## Required
+## Optional
 
 <table>
   <tr>
@@ -60,42 +61,51 @@ If you _really_ want to install VS 2015 on Windows Server 2012R2 over naked WinR
   <tr>
     <td><code>['visualstudio']['source']</code></td>
     <td>Url</td>
-    <td>http(s) root url to where all the ISOs are stored for VisualStudio installation</td>
+    <td>http(s) root url to all version/edition's ISOs are stored for VisualStudio installation.</td>
     <td></td>
   </tr>
-</table>
-
-## Optional
-
-<table>
   <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
+    <td><code>['visualstudio'][VERSION][EDITION]['source']</code></td>
+    <td>Url</td>
+    <td>
+    http(s) root url to this version/edition's ISO is stored for VisualStudio installation. VERSION and EDITION should be replaced with one of the supported VS versions/editions. This attribute when set takes precedence over node['visualstudio']['source'].
+    </td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>['visualstudio'][VERSION]['update']['source']</code></td>
+    <td>Url</td>
+    <td>http(s) root url to this version's update ISO is stored for installation.</td>
+    <td></td>
   </tr>
   <tr>
     <td><code>['visualstudio']['edition']</code></td>
     <td>Boolean</td>
-    <td>The VisualStudio edition to install, i.e. community, professional, premium, ultimate, testprofessional</td>
-    <td><code>ultimate</code></td>
+    <td>The VisualStudio edition to install, i.e. community, professional, premium, ultimate, testprofessional.</td>
+    <td><code>community</code></td>
   </tr>
   <tr>
     <td><code>['visualstudio']['version']</code></td>
     <td>Integer</td>
-    <td>The VisualStudio version to install, i.e. 2010, 2012, 2013, 2015</td>
-    <td><code>2012</code></td>
+    <td>The VisualStudio version to install, i.e. 2010, 2012, 2013, 2015.</td>
+    <td><code>2015</code></td>
   </tr>
   <tr>
     <td><code>['visualstudio']['enable_nuget_package_restore']</code></td>
     <td>Boolean</td>
-    <td>Sets the system wide environment variable to enable MSBuild/VisualStudio package restore on build</td>
+    <td>Sets the system wide environment variable to enable MSBuild/VisualStudio package restore on build.</td>
     <td><code>True</code></td>
   </tr>
   <tr>
     <td><code>['visualstudio']['installs']</code></td>
     <td>Array</td>
     <td>An array of hashes that contain the various versions and editions of VS to install. See Usage below for an example.</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>['visualstudio']['install_items'][FEATURE]['selected']</code></td>
+    <td>Boolean</td>
+    <td>Configures the feature on/off. This currentnly applies to all versions/editions being installed.</td>
     <td></td>
   </tr>
   <tr>
@@ -108,9 +118,7 @@ If you _really_ want to install VS 2015 on Windows Server 2012R2 over naked WinR
 
 # Usage
 
-Set the `node['visualstudio']['source']` attribute to the download location of the VisualStudio ISO, for example: http://example.com/installs. Then add `'visualstudio::default'` to your runlist. The same source attribute is used for all editions, versions, and updates.
-
-By default this cookbook assumes you're installing VisualStudio 2012 Ultimate. If you'd like to install another edition set the 'edition' attribute to: 'community', 'professional', 'premium', or 'testprofessional'. If you'd like to install a different version set the 'version' attribute to: '2010', '2012', '2013', '2015'.
+Add `'visualstudio::default'` to your runlist. This will install VS 2015 Community Edition from the publicly available ISO. If you'd like to install another edition set the 'edition' attribute to: 'community', 'professional', 'premium', or 'testprofessional'. If you'd like to install a different version set the 'version' attribute to: '2010', '2012', '2013', '2015'.
 
 If you need to install multiple different versions/editions of VisualStudio on the same node you must instead set the 'installs' attribute. If the installs attribute is set then the version and edition attributes are ignored.
 
@@ -124,25 +132,33 @@ node['visualstudio']['installs'] = [{
 }]
 ```
 
-Each VS version/edition pair has their own unique attributes which can be overridden. The most common to override would be `checksum` and `filename`. For example, we can override the VS 2013 Professional checksum and filename attributes like so:
+Each VS version/edition pair has their own unique attributes which can be overridden. The most common to override would be `checksum`,  `filename`, and `source`. For example, we can override the VS 2013 Professional checksum and filename attributes like so:
 
 ```ruby
 node.override['visualstudio']['2013']['professional']['checksum'] = 'c4930bb83454a2fcbc762da79a4227e92fdbef7d0b395c619829a36c3fb4ec54'
 node.override['visualstudio']['2013']['professional']['filename'] = 'My_vs2013.iso'
+node.override['visualstudio']['2013']['professional']['source'] = 'https://myartifactrepo.example.com/visualstudio/'
 ```
 
-Unlike newer versions of VisualStudio which use an AdminDeployment.xml file, VS 2010 uses an unattend.ini file, which, among other things, is OS-specific. By default, this cookbook uses VS 2010's `/q` option, which works for all Windows versions and specifies a default installation. To customize the installation, you may specify an unattend.ini template instead. The use of a template instead of a static file is required due to relative paths inside the file. This cookbook includes an unattend.ini template sample.
+VisualStudio 2013 and newer have default public download links for all their ISOs. If you're using an older version (2010, 2012) you must first set a download source. Either set the global `node['visualstudio']['source']` download URL or the version/edition specific download source, e.g. `node['visualstudio']['2012']['professional']['source']`. You can also use these same attributes to override the ISO location for newer VS versions.
 
-To customize the AdminDeployment.xml file for adding features to an unattended install in VisualStudio versions over 2010 edit the node attribute `node['visualstudio']['install_items']`
+## Customizing Installed Features
+### VS 2012 and Newer
+
+To customize the AdminDeployment.xml file for adding features to an unattended install in VisualStudio 2012 and newer edit the node attribute `node['visualstudio']['install_items']`
 adding the 'id' of the `<SelectableItemCustomization>` you want to install, it's 'Selected', 'Hidden', and 'FriendlyName' can then be set assuming the item has the attribute(s).
 
 For example:
 `node['visualstudio']['install_items']['NativeLanguageSupport_VCV1']['selected']= true`
 while you could also modify the 'Hidden' and 'FriendlyName' attributes for 'NativeLanguageSupport_VCV1' there's rarely a reason to as you won't see the installer anyway.
 
-Note:
+__Note:__
 Do not edit the `node['visualstudio'][<version>][<edition>]['default_install_items']` these are the defaults for the AdminDeployment.xml file if you wish to change the settings see above,
 `node['visualstudio']['install_items']` is merged with these effectively overwriting with the desired settings.
+
+### VS 2010
+
+Unlike newer versions of VisualStudio which use an AdminDeployment.xml file, VS 2010 uses an unattend.ini file, which, among other things, is OS-specific. By default, this cookbook uses VS 2010's `/q` option, which works for all Windows versions and specifies a default installation. To customize the installation, you may specify an unattend.ini template instead. The use of a template instead of a static file is required due to relative paths inside the file. This cookbook includes an unattend.ini template sample.
 
 # Recipes
 
@@ -161,7 +177,7 @@ Logs a warning if .NET 4.5.x is not installed. This recipe does not curently che
 # Optional Recipes
 
 ## install_update
-Installs VS updates from the corresponding VS update ISO that is publicly downloadable from Microsoft. Add this to your runlist to update all versions of VS in your installs attribute array. By default you must place the iso in the same folder as the main VS ISO since they all share the same source attribute.
+Installs VS updates from the corresponding VS update ISO that is publicly downloadable from Microsoft. Add this to your runlist to update all versions of VS in your installs attribute array.
 
 ## install_vsto
 Installs the Microsoft Office Developer Tools for Visual Studio 2012. Add this to your runlist if you need Office development tools for Office plugin development. Other versions of VS are not currently supported and will log a Chef warning.
@@ -194,8 +210,6 @@ If the installer fails very early in the install process, check a few of things:
 
 # TO DO
 
-- Support all VS 2010 editions
-- Support all VS 2015 editions
 - Check for .NET 4.6 installed, but only if VS 2015 is going to be installed
 - Support VSTO on all versions of VS
 - More tests

--- a/attributes/vs2010.rb
+++ b/attributes/vs2010.rb
@@ -45,8 +45,9 @@ default['visualstudio']['2010']['ultimate']['config_file'] = nil
 
 # VS 2010 SP1
 default['visualstudio']['2010']['update']['filename'] = 'VS2010SP1dvd1.iso'
-default['visualstudio']['2010']['update']['source'] = node['visualstudio']['source']
 default['visualstudio']['2010']['update']['checksum'] =
   'fce24f0e3f95fdeb54b806be3266f3b61a1e6b5b78c7e6c13c36fc1a6f5ba0ad'
 default['visualstudio']['2010']['update']['package_name'] =
   'Microsoft Visual Studio 2010 Service Pack 1'
+default['visualstudio']['2010']['update']['default_source'] =
+  'http://download.microsoft.com/download/E/B/A/EBA0A152-F426-47E6-9E3F-EFB686E3CA20'

--- a/attributes/vs2012.rb
+++ b/attributes/vs2012.rb
@@ -219,13 +219,14 @@ default['visualstudio']['2012']['ultimate']['default_install_items'].tap do |h|
 end
 
 # Update 5
-# https://download.microsoft.com/download/1/7/A/17A8493D-BB25-4811-8242-CCCB74EF982E/VS2012.5.iso
 default['visualstudio']['2012']['update']['filename'] = 'VS2012.5.iso'
 default['visualstudio']['2012']['update']['source'] = node['visualstudio']['source']
 default['visualstudio']['2012']['update']['checksum'] =
   '405bad3d4249dd94b4fa309bb482ade9ce63d968b59cac9e2d63b0a24577285e'
 default['visualstudio']['2012']['update']['package_name'] =
   'Visual Studio 2012 Update 5 (KB2707250)'
+default['visualstudio']['2012']['update']['default_source'] =
+  'https://download.microsoft.com/download/1/7/A/17A8493D-BB25-4811-8242-CCCB74EF982E'
 
 # VS 2012 Office developer tools
 default['visualstudio']['2012']['vsto']['installer_file'] = 'officetools_bundle.exe'

--- a/attributes/vs2012.rb
+++ b/attributes/vs2012.rb
@@ -220,7 +220,6 @@ end
 
 # Update 5
 default['visualstudio']['2012']['update']['filename'] = 'VS2012.5.iso'
-default['visualstudio']['2012']['update']['source'] = node['visualstudio']['source']
 default['visualstudio']['2012']['update']['checksum'] =
   '405bad3d4249dd94b4fa309bb482ade9ce63d968b59cac9e2d63b0a24577285e'
 default['visualstudio']['2012']['update']['package_name'] =

--- a/attributes/vs2013.rb
+++ b/attributes/vs2013.rb
@@ -23,22 +23,26 @@
 default['visualstudio']['2013']['install_dir'] =
   (ENV['ProgramFiles(x86)'] || 'C:\Program Files (x86)') + '\Microsoft Visual Studio 12.0'
 
-# Test Professional
+# Test Professional w/Update5
 default['visualstudio']['2013']['testprofessional']['installer_file'] = 'vs_testprofessional.exe'
 default['visualstudio']['2013']['testprofessional']['filename'] = 'VS2013_RTM_TESTPRO_ENU.iso'
 default['visualstudio']['2013']['testprofessional']['package_name'] =
   'Microsoft Visual Studio Test Professional 2013'
 default['visualstudio']['2013']['testprofessional']['checksum'] =
   'b4930bb83454a2fcbc762da79a4227e92fdbef7d0b395c619829a36c3fb4ec78'
+default['visualstudio']['2013']['testprofessional']['default_source'] =
+  'http://download.microsoft.com/download/4/0/6/406E397F-EDBE-4437-B64F-40DF7A92A26E'
 
-# Professional
+# Professional w/Update5
 default['visualstudio']['2013']['professional']['installer_file'] = 'vs_professional.exe'
 default['visualstudio']['2013']['professional']['filename'] =
-  'en_visual_studio_professional_2013_x86_dvd_3175298.iso'
+  'vs2013.5_pro_enu.iso'
 default['visualstudio']['2013']['professional']['package_name'] =
   'Microsoft Visual Studio Professional 2013'
 default['visualstudio']['2013']['professional']['checksum'] =
-  '3bf357ca41b3c8ee04dcb7eb4151674448627c8c649e817bc225a75172845d60'
+  '85fdde5e636774c9869bcaab4d2ded83e7a9388014771bf228577eea6112b033'
+default['visualstudio']['2013']['professional']['default_source'] =
+  'http://download.microsoft.com/download/F/2/E/F2EFF589-F7D7-478E-B3AB-15F412DA7DEB'
 
 # Defaults for the <SelectableItemCustomization> in AdminDeployment.xml
 # These are DEFAULTS. If you wish to change the selectable items installed edit the node attributes
@@ -90,12 +94,14 @@ default['visualstudio']['2013']['professional']['default_install_items'].tap do 
   h['WinSDKHidden']['selected'] = true
 end
 
-# Premium
+# Premium w/Update5
 default['visualstudio']['2013']['premium']['installer_file'] = 'vs_premium.exe'
-default['visualstudio']['2013']['premium']['filename'] = 'vs2013.4_prem_enu.iso'
+default['visualstudio']['2013']['premium']['filename'] = 'vs2013.5_prem_enu.iso'
 default['visualstudio']['2013']['premium']['package_name'] = 'Microsoft Visual Studio Premium 2013'
 default['visualstudio']['2013']['premium']['checksum'] =
-  '0e08d3eb682545b42b322dff3a5d97ed8d19ade87aa340d6a2064a24f78a2c01'
+  'bec971770b06524d82aafc370673022e9502161a8cb1840d51da08772cb69801'
+default['visualstudio']['2013']['premium']['default_source'] =
+  'http://download.microsoft.com/download/6/5/F/65F510B7-D597-4E80-8EFE-86DDCFCC7C43'
 
 # Defaults for the <SelectableItemCustomization> in AdminDeployment.xml
 # These are DEFAULTS. If you wish to change the selectable items installed edit the node attributes
@@ -149,13 +155,15 @@ default['visualstudio']['2013']['premium']['default_install_items'].tap do |h|
   h['WinSDKHidden']['selected'] = true
 end
 
-# Ultimate
+# Ultimate w/Update5
 default['visualstudio']['2013']['ultimate']['installer_file'] = 'vs_ultimate.exe'
-default['visualstudio']['2013']['ultimate']['filename'] = 'vs2013.4_ult_enu.iso'
+default['visualstudio']['2013']['ultimate']['filename'] = 'vs2013.5_ult_enu.iso'
 default['visualstudio']['2013']['ultimate']['package_name'] =
   'Microsoft Visual Studio Ultimate 2013'
 default['visualstudio']['2013']['ultimate']['checksum'] =
-  '61eefab736579fa8c58a524338a0dc46d15c1bbaf978b660ab93bedb8847756c'
+  '43a2f252cb3b21cce1149c212f436e9e8190ae73b489f951601a546b62752bef'
+default['visualstudio']['2013']['ultimate']['default_source'] =
+  'http://download.microsoft.com/download/E/2/A/E2ADF1BE-8FA0-4436-A260-8780444C8355'
 
 # Defaults for the <SelectableItemCustomization> in AdminDeployment.xml
 # These are DEFAULTS. If you wish to change the selectable items installed edit the node attributes
@@ -209,22 +217,15 @@ default['visualstudio']['2013']['ultimate']['default_install_items'].tap do |h|
   h['WinSDKHidden']['selected'] = true
 end
 
-# Update 5
-# http://download.microsoft.com/download/A/F/9/AF95E6F8-2E6E-49D0-A48A-8E918D7FD768/VS2013.5.iso
-default['visualstudio']['2013']['update']['filename'] = 'VS2013.5.iso'
-default['visualstudio']['2013']['update']['source'] = node['visualstudio']['source']
-default['visualstudio']['2013']['update']['checksum'] =
-  'baa3e1286bf847ffb1ba6191f14494aa5f0b856ea258284d99924481ea83c6cf'
-default['visualstudio']['2013']['update']['package_name'] =
-  'Visual Studio 2013 Update 5 (KB3021976)'
-
-# Community
+# Community w/Update5
 default['visualstudio']['2013']['community']['installer_file'] = 'vs_community.exe'
 default['visualstudio']['2013']['community']['filename'] = 'vs2013.5_ce_enu.iso'
 default['visualstudio']['2013']['community']['package_name'] =
   'Microsoft Visual Studio Community 2013 with Update 5'
 default['visualstudio']['2013']['community']['checksum'] =
   '7de2340d9570895451c5f5d9f2081db860a4f753e7596e31b2742390a6d0e6bc'
+default['visualstudio']['2013']['community']['default_source'] =
+  'http://download.microsoft.com/download/A/A/D/AAD1AA11-FF9A-4B3C-8601-054E89260B78'
 
 # Defaults for the <SelectableItemCustomization> in AdminDeployment.xml
 # These are DEFAULTS. If you wish to change the selectable items installed edit the node attributes
@@ -271,3 +272,12 @@ default['visualstudio']['2013']['community']['default_install_items'].tap do |h|
   h['WinJSHidden']['selected'] = true
   h['WinSDKHidden']['selected'] = true
 end
+
+# Update 5
+default['visualstudio']['2013']['update']['filename'] = 'VS2013.5.iso'
+default['visualstudio']['2013']['update']['checksum'] =
+  'baa3e1286bf847ffb1ba6191f14494aa5f0b856ea258284d99924481ea83c6cf'
+default['visualstudio']['2013']['update']['package_name'] =
+  'Visual Studio 2013 Update 5 (KB3021976)'
+default['visualstudio']['2013']['update']['default_source'] =
+  'http://download.microsoft.com/download/A/F/9/AF95E6F8-2E6E-49D0-A48A-8E918D7FD768'

--- a/attributes/vs2015.rb
+++ b/attributes/vs2015.rb
@@ -23,14 +23,26 @@
 default['visualstudio']['2015']['install_dir'] =
   (ENV['ProgramFiles(x86)'] || 'C:\Program Files (x86)') + '\Microsoft Visual Studio 14.0'
 
-# Professional
+# Test Professional w/Update1
+default['visualstudio']['2015']['testprofessional']['installer_file'] = 'vs_testprofessional.exe'
+default['visualstudio']['2015']['testprofessional']['filename'] = 'vs2015.testpro_enu.iso'
+default['visualstudio']['2015']['testprofessional']['package_name'] =
+  'Microsoft Visual Studio Test Professional 2015'
+default['visualstudio']['2015']['testprofessional']['checksum'] =
+  '4c83fd0c971d6249b7f87e7fb20ccbf41d4ff4814a0660c4f89d6884408c191b'
+default['visualstudio']['2015']['testprofessional']['default_source'] =
+  'http://download.microsoft.com/download/8/5/6/856E021B-39D6-4593-B7BB-2F8D1178EBCB'
+
+# Professional w/Update1
 default['visualstudio']['2015']['professional']['installer_file'] = 'vs_professional.exe'
 default['visualstudio']['2015']['professional']['filename'] =
-  'en_visual_studio_professional_2015_x86_x64_dvd_6846629.iso'
+  'vs2015.1.pro_enu.iso'
 default['visualstudio']['2015']['professional']['package_name'] =
   'Microsoft Visual Studio Professional 2015'
 default['visualstudio']['2015']['professional']['checksum'] =
-  '8d6d9a13ccb7f409161518e07e610c12180f415995fa417fa1343a4f2f4ce74b'
+  '7badca090697567ca679159afa21f5d84605bda6a66f99283185dacd24d61e6b'
+default['visualstudio']['2015']['professional']['default_source'] =
+  'http://download.microsoft.com/download/3/6/A/36A72A3F-711B-4738-B4C6-C668A508D2EE'
 
 # Defaults for the <SelectableItemCustomization> in AdminDeployment.xml
 # These are DEFAULTS. If you wish to change the selectable items installed edit the node attributes
@@ -178,6 +190,8 @@ default['visualstudio']['2015']['community']['package_name'] =
   'Microsoft Visual Studio Community 2015'
 default['visualstudio']['2015']['community']['checksum'] =
   'ce124aec77f970605bb38352e59e7b3c7b51c0367f213cf5e6165b2698c1ba20'
+default['visualstudio']['2015']['community']['default_source'] =
+  'http://download.microsoft.com/download/b/e/d/bedddfc4-55f4-4748-90a8-ffe38a40e89f'
 
 # Defaults for the <SelectableItemCustomization> in AdminDeployment.xml
 # These are DEFAULTS. If you wish to change the selectable items installed edit the node attributes
@@ -312,14 +326,16 @@ default['visualstudio']['2015']['community']['default_install_items'].tap do |h|
   h['VS_SDK_Breadcrumb_GroupV1']['friendly_name'] = 'Visual Studio Extensibility Tools'
 end
 
-# Enterprise
+# Enterprise w/Update1
 default['visualstudio']['2015']['enterprise']['installer_file'] = 'vs_enterprise.exe'
 default['visualstudio']['2015']['enterprise']['filename'] =
-  'en_visual_studio_enterprise_2015_x86_x64_dvd_6850497.iso'
+  'vs2015.1.ent_enu.iso'
 default['visualstudio']['2015']['enterprise']['package_name'] =
   'Microsoft Visual Studio Enterprise 2015'
 default['visualstudio']['2015']['enterprise']['checksum'] =
-  '12db74d1e6243924c187069ad95cee58b687dcb9ba2d302fc6ae889fb4ae7694'
+  'ea91fec301f1c105ef39826a72d21de5923f3d7a5857c25af3163526dd768639'
+default['visualstudio']['2015']['enterprise']['default_source'] =
+  'http://download.microsoft.com/download/6/C/9/6C95B548-64A9-4637-A7F2-EB2A750C7504'
 
 # Defaults for the <SelectableItemCustomization> in AdminDeployment.xml
 # These are DEFAULTS. If you wish to change the selectable items installed edit the node attributes

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -26,16 +26,31 @@ module Visualstudio
       installs.map { |i| i['version'] }.uniq
     end
 
-    # Fails the Chef run if the visualstudio source attribute is not set
-    def assert_source_attribute_is_set
-      # Ensure the user specified the required source attribute
-      if node['visualstudio']['source'].nil?
-        raise 'The required attribute node[\'visualstudio\'][\'source\'] is empty, ' \
-          'set this and run again!'
-      end
+    # Gets the version/edition ISO download URL or raises an error
+    def source_download_url(version, edition)
+      src = iso_source(version, edition)
+      assert_src_is_not_nil(src, version, edition)
+      ::File.join(src, node['visualstudio'][version][edition]['filename'])
     end
 
     private
+
+    # Gets the version/edition ISO download root URL
+    def iso_source(version, edition)
+      src = node['visualstudio'][version][edition]['default_source']
+      src = node['visualstudio']['source'] if node['visualstudio']['source']
+      src = node['visualstudio'][version][edition]['source'] if node['visualstudio'][version][edition]['source']
+      src
+    end
+
+    # Fails the Chef run if the visualstudio download source is not set
+    def assert_src_is_not_nil(src, version, edition)
+      if src.nil?
+        raise 'The ISO download source is empty! '\
+          "Set the node['visualstudio']['#{version}']['#{edition}']['source'] " \
+          'or node[\'visualstudio\'][\'source\'] attribute and run again!'
+      end
+    end
 
     def windows_package_is_installed?(package_name)
       require 'win32/registry'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -21,21 +21,16 @@
 
 ::Chef::Recipe.send(:include, Visualstudio::Helper)
 
-assert_source_attribute_is_set
-
 # Install each specified edition/version
 installs.each do |install|
   version = install['version']
   edition = install['edition']
-
-  install_url = File.join(node['visualstudio']['source'],
-                          node['visualstudio'][version][edition]['filename'])
-
+  url = source_download_url(version, edition)
   visualstudio_edition "visualstudio_#{version}_#{edition}" do
     edition edition
     version version
     install_dir node['visualstudio'][version]['install_dir']
-    source install_url
+    source url
     product_key node['visualstudio'][version][edition]['product_key']
     package_name node['visualstudio'][version][edition]['package_name']
     checksum node['visualstudio'][version][edition]['checksum']

--- a/recipes/install_update.rb
+++ b/recipes/install_update.rb
@@ -21,19 +21,15 @@
 
 ::Chef::Recipe.send(:include, Visualstudio::Helper)
 
-assert_source_attribute_is_set
-
 # Create list of unique VS versions that have updates
 versions_with_updates = versions.reject { |v| node['visualstudio'][v]['update'].nil? }
 
 # Install updates for each VS version
 versions_with_updates.each do |version|
-  iso_src = ::File.join(node['visualstudio']['source'],
-                        node['visualstudio'][version]['update']['filename'])
-
+  url = source_download_url(version, 'update')
   visualstudio_update "visualstudio_#{version}_update" do
     install_dir node['visualstudio'][version]['install_dir']
-    source iso_src
+    source url
     package_name node['visualstudio'][version]['update']['package_name']
     checksum node['visualstudio'][version]['update']['checksum']
     preserve_extracted_files node['visualstudio']['preserve_extracted_files']

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -20,7 +20,7 @@ describe 'visualstudio::install' do
         end.converge(described_recipe)
       end
       it 'installs Visual Studio 2015 Professional when only edition attribute is set' do
-        url = 'http://localhost:8080/en_visual_studio_professional_2015_x86_x64_dvd_6846629.iso'
+        url = 'http://localhost:8080/vs2015.1.pro_enu.iso'
         expect(chef_run).to install_visualstudio_edition('visualstudio_2015_professional')
           .with(
             edition: 'professional',

--- a/spec/install_update_spec.rb
+++ b/spec/install_update_spec.rb
@@ -2,9 +2,7 @@
 describe 'visualstudio::install_update' do
   describe 'Visual Studio 2015 Community Edition' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2') do |node|
-        node.default['visualstudio']['source'] = 'http://localhost:8080'
-      end.converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2').converge(described_recipe)
     end
     it 'does not install any updates by default' do
       expect(chef_run).not_to install_visualstudio_update('visualstudio_2015_update')
@@ -17,7 +15,6 @@ describe 'visualstudio::install_update' do
   describe 'Visual Studio 2012 Ultimate Edition' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2') do |node|
-        node.default['visualstudio']['source'] = 'http://localhost:8080'
         node.override['visualstudio']['version'] = '2012'
         node.override['visualstudio']['edition'] = 'ultimate'
       end.converge(described_recipe)
@@ -26,7 +23,7 @@ describe 'visualstudio::install_update' do
       expect(chef_run).to install_visualstudio_update('visualstudio_2012_update')
         .with(
           install_dir: 'C:\Program Files (x86)\Microsoft Visual Studio 11.0',
-          source: 'http://localhost:8080/VS2012.5.iso',
+          source: 'https://download.microsoft.com/download/1/7/A/17A8493D-BB25-4811-8242-CCCB74EF982E/VS2012.5.iso',
           package_name: 'Visual Studio 2012 Update 5 (KB2707250)',
           checksum: '405bad3d4249dd94b4fa309bb482ade9ce63d968b59cac9e2d63b0a24577285e'
         )


### PR DESCRIPTION
Makes the cookbook easier to use OOB:
- Allows users to override the source ISO download URL on a per version basis
- Defaults VS 2013 and 2015 download sources.
- Adds VS 2015 Test Professional w/Update1