### PR TITLE
Allowing overriding of the ISO extraction directory

### DIFF
--- a/providers/edition.rb
+++ b/providers/edition.rb
@@ -141,11 +141,11 @@ def installer_exe
 end
 
 def extracted_iso_dir
-  win_friendly_path(
-    ::File.join(
+  default_path = ::File.join(
       Chef::Config[:file_cache_path],
       new_resource.version,
       new_resource.edition
-    )
   )
+  extract_dir = node['visualstudio']['unpack_dir'] != nil ? node['visualstudio']['unpack_dir'] : default_path
+  win_friendly_path( extract_dir )
 end

--- a/providers/edition.rb
+++ b/providers/edition.rb
@@ -142,10 +142,10 @@ end
 
 def extracted_iso_dir
   default_path = ::File.join(
-      Chef::Config[:file_cache_path],
-      new_resource.version,
-      new_resource.edition
+    Chef::Config[:file_cache_path],
+    new_resource.version,
+    new_resource.edition
   )
-  extract_dir = node['visualstudio']['unpack_dir'] != nil ? node['visualstudio']['unpack_dir'] : default_path
-  win_friendly_path( extract_dir )
+  extract_dir = node['visualstudio']['unpack_dir'].nil? ? default_path : node['visualstudio']['unpack_dir']
+  win_friendly_path(extract_dir)
 end

--- a/providers/update.rb
+++ b/providers/update.rb
@@ -65,8 +65,8 @@ end
 
 def extracted_iso_dir
   default_path = ::File.join(
-      Chef::Config[:file_cache_path],
-      Digest::MD5.hexdigest(new_resource.package_name)
+    Chef::Config[:file_cache_path],
+    Digest::MD5.hexdigest(new_resource.package_name)
   )
   extract_dir = node['visualstudio']['unpack_dir'].nil? ? default_path : node['visualstudio']['unpack_dir']
   win_friendly_path(extract_dir)

--- a/providers/update.rb
+++ b/providers/update.rb
@@ -64,12 +64,12 @@ action :install do
 end
 
 def extracted_iso_dir
-  win_friendly_path(
-    ::File.join(
+  default_path = ::File.join(
       Chef::Config[:file_cache_path],
       Digest::MD5.hexdigest(new_resource.package_name)
-    )
   )
+  extract_dir = node['visualstudio']['unpack_dir'].nil? ? default_path : node['visualstudio']['unpack_dir']
+  win_friendly_path(extract_dir)
 end
 
 def install_log_file


### PR DESCRIPTION
Sometimes, the chef cache is on a drive with not enough space to extract and install, this allows for simple overriding via wrapper cookbooks