### PR TITLE
Fix output encoding error

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ skip_tags: true
 clone_depth: 1
 
 install:
-  - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
+  - ps: & cmd /c; iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
   - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
   - ps: $PSVersionTable
   - c:\opscode\chefdk\bin\chef.bat exec ruby --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ skip_tags: true
 clone_depth: 1
 
 install:
-  - ps: & cmd /c; iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
+  - ps: (& cmd /c); iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
   - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
   - ps: $PSVersionTable
   - c:\opscode\chefdk\bin\chef.bat exec ruby --version


### PR DESCRIPTION
- Fix output encoding error in PowerShell script.  @chaim1221 reported it as an [issue](https://github.com/windowschefcookbooks/visualstudio/issues/25) since it's polluting the otherwise clean looking build log.  The solution is to start a cmd console so that [Console]::OutputEncoding has something to modify.  Whether or not you encounter that error depends on how PowerShell was invoked.  Some contexts include a cmd console already, while others do not.